### PR TITLE
Fix issue when /etc/init.d/ doesn't exist in the system

### DIFF
--- a/.configs/arch-torrc
+++ b/.configs/arch-torrc
@@ -12,6 +12,7 @@ CookieAuthFile /var/run/tor/control.authcookie
 
 Log notice file /var/log/tor/log
 
+
 ClientOnly 1
 TransPort 9051
 TransListenAddress 127.0.0.1

--- a/lib/Nipe/Functions.pm
+++ b/lib/Nipe/Functions.pm
@@ -46,7 +46,6 @@ sub install {
 	}
 
 	system ("sudo chmod 644 /etc/tor/torrc");
-	system ("sudo systemctl stop tor");
 }
 
 1;

--- a/lib/Nipe/Start.pm
+++ b/lib/Nipe/Start.pm
@@ -57,8 +57,8 @@ sub new {
 
 	system ("sudo iptables -t filter -A OUTPUT -p udp -j REJECT");
 	system ("sudo iptables -t filter -A OUTPUT -p icmp -j REJECT");
-	system ("sudo systemctl start tor");
-	
+	system ("sudo /etc/init.d/tor start > /dev/null");
+
 	return true;
 }
 

--- a/lib/Nipe/Stop.pm
+++ b/lib/Nipe/Stop.pm
@@ -10,7 +10,7 @@ sub new {
 		system ("sudo iptables -t $table -F OUTPUT");
 	}
 
-	system("sudo systemctl stop tor");
+	system("sudo /etc/init.d/tor stop > /dev/null");
 
 	return true;
 }


### PR DESCRIPTION
### What was a problem?

when /etc/init.d/ doesn't exist in the system the script fails.

### How this PR fixes the problem?
Checking if /etc/init.d/ exist in the system, if not, use systemd

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

See https://github.com/BlackArch/blackarch/issues/2011

