### PR TITLE
Allow custom configuration without overwriting tor's system config

### DIFF
--- a/lib/Nipe/Helper.pm
+++ b/lib/Nipe/Helper.pm
@@ -10,6 +10,7 @@ sub new {
 		\r\t-------       -----------
 		\r\tinstall       Install dependencies
 		\r\t  -f          Overwrite Tor config file in /etc/tor/torrc
+		\r\t  -c <file>   Specify a custom location to install Tor's config file
 		\r\tstart         Start routing
 		\r\tstop          Stop routing
 		\r\trestart       Restart the Nipe process

--- a/lib/Nipe/Helper.pm
+++ b/lib/Nipe/Helper.pm
@@ -9,6 +9,7 @@ sub new {
 		\r\tCommand       Description
 		\r\t-------       -----------
 		\r\tinstall       Install dependencies
+		\r\t  -f          Overwrite Tor config file in /etc/tor/torrc
 		\r\tstart         Start routing
 		\r\tstop          Stop routing
 		\r\trestart       Restart the Nipe process

--- a/lib/Nipe/Install.pm
+++ b/lib/Nipe/Install.pm
@@ -5,6 +5,8 @@ package Nipe::Install;
 use Nipe::Device;
 
 sub new {
+	shift; # ignore class name
+	my $force_cfg = shift;
 	my $operationalSystem = Nipe::Device -> getSystem();
 
 	if ($operationalSystem eq "debian") {
@@ -23,8 +25,16 @@ sub new {
 		system ("sudo pacman -S tor iptables");
 	}
 
-	system ("sudo cp .configs/$operationalSystem-torrc /etc/tor/torrc");
-	system ("sudo chmod 644 /etc/tor/torrc");
+	if (defined($force_cfg)) {
+		print "[.] Overwriting system Tor's config file\n";
+		print "[.]   .configs/$operationalSystem-torrc -> /etc/tor/torrc\n";
+		system ("sudo cp .configs/$operationalSystem-torrc /etc/tor/torrc");
+		system ("sudo chmod 644 /etc/tor/torrc");
+	}
+
+	else {
+		print "[.] Refer to our custom Tor config files in project home\n";
+	}
 
 	if (-e "/etc/init.d/tor") {
 		system ("sudo /etc/init.d/tor stop > /dev/null");

--- a/lib/Nipe/Install.pm
+++ b/lib/Nipe/Install.pm
@@ -6,7 +6,8 @@ use Nipe::Device;
 
 sub new {
 	shift; # ignore class name
-	my $force_cfg = shift;
+	my ($force_cfg, $custom_cfg) = @_;
+	my $tor_cfg = "/etc/tor/torrc";
 	my $operationalSystem = Nipe::Device -> getSystem();
 
 	if ($operationalSystem eq "debian") {
@@ -26,10 +27,18 @@ sub new {
 	}
 
 	if (defined($force_cfg)) {
-		print "[.] Overwriting system Tor's config file\n";
-		print "[.]   .configs/$operationalSystem-torrc -> /etc/tor/torrc\n";
-		system ("sudo cp .configs/$operationalSystem-torrc /etc/tor/torrc");
-		system ("sudo chmod 644 /etc/tor/torrc");
+		if (defined($custom_cfg)) {
+			$tor_cfg = $custom_cfg;
+			print "[.] Writing Nipe's custom Tor config file\n";
+		}
+
+		else {
+			print "[.] Overwriting system Tor's config file\n";
+		}
+
+		print "[.]   .configs/$operationalSystem-torrc -> $tor_cfg\n";
+		system ("sudo cp .configs/$operationalSystem-torrc $tor_cfg");
+		system ("sudo chmod 644 $tor_cfg");
 	}
 
 	else {

--- a/lib/Nipe/Install.pm
+++ b/lib/Nipe/Install.pm
@@ -7,28 +7,23 @@ use Nipe::Device;
 sub new {
 	my $operationalSystem = Nipe::Device -> getSystem();
 
-	system ("sudo mkdir -p /etc/tor");
-
 	if ($operationalSystem eq "debian") {
 		system ("sudo apt-get install tor iptables");
-		system ("sudo cp .configs/debian-torrc /etc/tor/torrc");
 	}
 	
 	elsif ($operationalSystem eq "fedora") {
 		system ("sudo dnf install tor iptables");
-		system ("sudo cp .configs/fedora-torrc /etc/tor/torrc");
 	}
 
 	elsif ($operationalSystem eq "centos") {
 		system ("sudo yum install epel-release tor iptables");
-		system ("sudo cp .configs/centos-torrc /etc/tor/torrc");
 	}
 
 	else {
 		system ("sudo pacman -S tor iptables");
-		system ("sudo cp .configs/arch-torrc /etc/tor/torrc");
 	}
 
+	system ("sudo cp .configs/$operationalSystem-torrc /etc/tor/torrc");
 	system ("sudo chmod 644 /etc/tor/torrc");
 
 	if (-e "/etc/init.d/tor") {

--- a/nipe.pl
+++ b/nipe.pl
@@ -27,7 +27,13 @@ sub main {
 			Nipe::Restart -> new();
 		}
 		case "install" {
-			Nipe::Install -> new();
+			my $force_cfg = undef;
+
+			if ($ARGV[1] eq "-f") {
+				$force_cfg = 1;
+			}
+
+			Nipe::Install -> new($force_cfg);
 		}
 
 		Nipe::Helper -> new();

--- a/nipe.pl
+++ b/nipe.pl
@@ -28,12 +28,24 @@ sub main {
 		}
 		case "install" {
 			my $force_cfg = undef;
+			my $custom_cfg = undef;
 
 			if ($ARGV[1] eq "-f") {
 				$force_cfg = 1;
 			}
 
-			Nipe::Install -> new($force_cfg);
+			elsif ($ARGV[1] eq "-c") {
+				if (length($ARGV[2]) <= 0) {
+					print "[!] Invalid argument\n";
+					Nipe::Functions -> help();
+					exit;
+				}
+
+				$force_cfg = 1;
+				$custom_cfg = $ARGV[2];
+			}
+
+			Nipe::Install -> new($force_cfg, $custom_cfg);
 		}
 
 		Nipe::Helper -> new();


### PR DESCRIPTION
This patch mostly solves issue #28, allowing the user to force the custom config files from nipe's .config dir to replace tor's system config file or input a custom location to copy those, instead of overwriting anything.

For that, two new options were added to the "install" command, _-f_ and _-c_, being the first the flag to allow nipe to overwrite tor config file in /etc/tor/torrc, and the second allowing the user to pass a custom location to place nipe's custom tor config file. By default, the user now is only prompted with a message to "check nipe's custom configs".

I've tested the modifications locally, but shouldn't have any differences between distros for the changes here applied.

NOTE: this PR uses the branch "develop" as its base.