### PR TITLE
Add support for custom tor configuration file entered by the user

### DIFF
--- a/lib/Nipe/Helper.pm
+++ b/lib/Nipe/Helper.pm
@@ -12,6 +12,7 @@ sub new {
 		\r\t  -f          Overwrite Tor config file in /etc/tor/torrc
 		\r\t  -c <file>   Specify a custom location to install Tor's config file
 		\r\tstart         Start routing
+		\r\t  -c <file>   Specify a custom Tor config file to be used by Nipe
 		\r\tstop          Stop routing
 		\r\trestart       Restart the Nipe process
 		\r\tstatus        See status

--- a/lib/Nipe/Start.pm
+++ b/lib/Nipe/Start.pm
@@ -5,12 +5,14 @@ package Nipe::Start;
 use Nipe::Device;
 
 sub new {
-	my $dnsPort      = "9061";
-	my $transferPort = "9051";
+	shift; # discard class name
+	my $custom_cfg   = shift;
+	my $tor = Nipe::Device -> getTorConfig($custom_cfg);
+	my $dnsPort      = $tor->{dns_port};
+	my $transferPort = $tor->{trans_port};
+	my $network      = $tor->{network};
+	my $username     = $tor->{username};
 	my @table        = ("nat", "filter");
-	my $network      = "10.66.0.0/255.255.0.0";
-
-	my %device = Nipe::Device -> new();
 
 	if (-e "/etc/init.d/tor") {
 		system ("sudo /etc/init.d/tor start > /dev/null");
@@ -29,7 +31,7 @@ sub new {
 
 		system ("sudo iptables -t $table -F OUTPUT");
 		system ("sudo iptables -t $table -A OUTPUT -m state --state ESTABLISHED -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -m owner --uid $device{username} -j $target");
+		system ("sudo iptables -t $table -A OUTPUT -m owner --uid $username -j $target");
 
 		my $matchDnsPort = $dnsPort;
 

--- a/nipe.pl
+++ b/nipe.pl
@@ -18,7 +18,19 @@ sub main {
 			Nipe::Stop -> new();
 		}
 		case "start" {
-			Nipe::Start -> new();
+			my $custom_cfg = undef;
+
+			if ($ARGV[1] eq "-c") {
+				if (length($ARGV[2]) <= 0) {
+					print "[!] Invalid argument\n";
+					Nipe::Helper -> new();
+					exit;
+				}
+
+				$custom_cfg = $ARGV[2];
+			}
+
+			Nipe::Start -> new($custom_cfg);
 		}
 		case "status" {
 			Nipe::Status -> new();


### PR DESCRIPTION
Issue #36 is solved by this PR by allowing the user to pass a custom config file (from a different tor instance or something like that) using the '-c' flag with the 'start' command.

At the same time, issue #79 should also be solved through the default values added to the code in case the ID_LIKE key is not present in /etc/os-release file. However, in case we identify that issue #79 is more deeper we're going to need new patches to solve that.