### PR TITLE
Custom config and code refectoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@
   perl nipe.pl status
 ```
 
+It's important to note that inside `.config/` folder there are multiple custom configuration files specificaly
+crafted for certain distributions that are used in `install` command; each has its own `User` key, which __should
+not__ be changed. The `User` option is the default username used by each distro when their `tor` package gets
+installed, thus every personal data (usually placed in `/var/lib/tor` folder or through `DataDirectory` option) is
+owned by this user UID:GID.
+
+### Known issues
+
+##### SELinux blocking DNS port setting
+
+For those running a Linux distribution that make use of SELinux strict rules you may need to run the following
+command to allow DNS port setting to take effect:
+
+```
+# semanage port -a -t dns_port_t -p udp
+```
+
 ### Contribution
 
 - Your contributions and suggestions are heartily ♥ welcome. [**See here the contribution guidelines.**](/.github/CONTRIBUTING.md) Please, report bugs via [**issues page.**](https://github.com/GouveaHeitor/nipe/issues) See here the [**security policy.**](./github/SECURITY.md) (✿ ◕‿◕) 

--- a/lib/Nipe/Device.pm
+++ b/lib/Nipe/Device.pm
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl
+use strict;
+use warnings;
 
 package Nipe::Device;
 

--- a/lib/Nipe/Device.pm
+++ b/lib/Nipe/Device.pm
@@ -5,15 +5,18 @@ package Nipe::Device;
 use Config::Simple;
 
 sub new {
-	my $config    = Config::Simple -> new('/etc/os-release');
-	my $id_like   = $config -> param('ID_LIKE');
+	my %device = (
+		"username" => "",
+		"distribution"  => ""
+	);
+
+	my $config = new Config::Simple();
+	$config -> read('/etc/os-release') or die $config -> error();
+
+	# not all distros define ID_LIKE, thus setting a default value
+	my $id_like   = $config -> param('ID_LIKE') // "";
 	my $id_distro = $config -> param('ID');
 
-	my %device = (
-		"Username" => "",
-        "Distribution"  => ""
-    );
-	
 	if (($id_like =~ /[F,f]edora/) || ($id_distro =~ /[F,f]edora/)) {
 		$device{username} = "toranon";
 		$device{distribution} = "fedora";
@@ -30,6 +33,30 @@ sub new {
 	}
 
 	return %device;
+}
+
+sub parseTorConfig {
+	shift;
+	my $cfg_file = shift;
+	my %device = new();
+
+	if (not defined($cfg_file)) {
+		$cfg_file = "/etc/tor/torrc";
+	}
+
+	my $config = new Config::Simple();
+	$config -> read($cfg_file) or die $config -> error();
+
+	my %tor_config = (
+		"username" => $config -> param('User') // $device{username},
+		"is_daemon" => $config -> param('RunAsDaemon') // 1,
+		"pid_file" => $config -> param('PidFile') // ".nipe_tor.pid",
+		"trans_port" => $config -> param('TransPort') // 9051,
+		"dns_port" => $config -> param('DNSPort') // 9061,
+		"network" => $config -> param('VirtualAddrNetwork') // "10.66.0.0/255.255.0.0"
+	);
+
+	return %tor_config;
 }
 
 1;

--- a/lib/Nipe/Helper.pm
+++ b/lib/Nipe/Helper.pm
@@ -1,10 +1,11 @@
-#!/usr/bin/env perl
+use strict;
+use warnings;
 
 package Nipe::Helper;
 
 sub new {
 	print "
-		\r\Core Commands
+		\rCore Commands
 		\r==============
 		\r\tCommand       Description
 		\r\t-------       -----------
@@ -18,8 +19,6 @@ sub new {
 		\r\tstatus        See status
 
 		\rCopyright (c) 2015 - 2020 | Heitor Gouvêa\n\n";
-
-	return true;
 }
 
 1;

--- a/lib/Nipe/Helper.pm
+++ b/lib/Nipe/Helper.pm
@@ -12,6 +12,7 @@ sub new {
 		\r\t  -f          Overwrite Tor config file in /etc/tor/torrc
 		\r\t  -c <file>   Specify a custom location to install Tor's config file
 		\r\tstart         Start routing
+		\r\t  -c <file>   Specify a custom Tor config file to be used by Nipe
 		\r\tstop          Stop routing
 		\r\trestart       Restart the Nipe process
 		\r\tstatus        See status

--- a/lib/Nipe/Install.pm
+++ b/lib/Nipe/Install.pm
@@ -2,6 +2,7 @@
 
 package Nipe::Install;
 
+use File::Which;
 use Nipe::Device;
 
 sub new {
@@ -13,19 +14,27 @@ sub new {
 	my %device = Nipe::Device -> new();
 
 	if ($device{distribution} eq "debian") {
-		system ("sudo apt-get install tor iptables");
+		system ("sudo apt-get -y install tor iptables");
 	}
 	
 	elsif ($device{distribution} eq "fedora") {
-		system ("sudo dnf install tor iptables");
+		system ("sudo dnf -y install tor iptables");
 	}
 
 	elsif ($device{distribution} eq "centos") {
-		system ("sudo yum install epel-release tor iptables");
+		system ("sudo yum -y install epel-release tor iptables");
 	}
 
 	else {
-		system ("sudo pacman -S tor iptables");
+		system ("sudo pacman --noconfirm -S tor iptables");
+	}
+
+	if (not defined(which("tor"))) {
+		die ("[!] tor was not correctly installed\n");
+	}
+
+	if (not defined(which("iptables"))) {
+		die ("[!] iptables was not correctly installed\n");
 	}
 
 	if (defined($force_cfg)) {
@@ -45,14 +54,6 @@ sub new {
 
 	else {
 		print "[.] Refer to our custom Tor config files in project home\n";
-	}
-
-	if (-e "/etc/init.d/tor") {
-		system ("sudo /etc/init.d/tor stop > /dev/null");
-	}
-
-	else {
-		system ("sudo systemctl stop tor");
 	}
 
 	return true;

--- a/lib/Nipe/Install.pm
+++ b/lib/Nipe/Install.pm
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl
+use strict;
+use warnings;
 
 package Nipe::Install;
 
@@ -55,8 +56,6 @@ sub new {
 	else {
 		print "[.] Refer to our custom Tor config files in project home\n";
 	}
-
-	return true;
 }
 
 1;

--- a/lib/Nipe/Start.pm
+++ b/lib/Nipe/Start.pm
@@ -2,24 +2,96 @@
 
 package Nipe::Start;
 
+use File::Which;
 use Nipe::Device;
 
 sub new {
-	my $dnsPort      = "9061";
-	my $transferPort = "9051";
+	shift; # discard class name
+	my $custom_cfg = shift;
+
+	# "start" command may run without a prior "install" command, thus it's
+	# better to check pkg dependency first
+	if (not defined(which("tor"))) {
+		die ("[!] Tor not installed. First run Nipe \"install\"\n");
+	}
+
+	if (not defined(which("iptables"))) {
+		die ("[!] Iptables not installed. First run Nipe \"install\"\n");
+	}
+
+	my %parsed_cfg = callTor($custom_cfg);
+	print "[.] Tor executed with success\n";
+	callIptables(\%parsed_cfg);
+	print "[.] Firewall rules set with success\n";
+	print "[.] Nipe initialized with success\n";
+
+	return true;
+}
+
+# Due to non-standard ways to call tor throughout Linux distros from start
+# scripts, we are going to handle that manually:
+# 1. some distros has multi-instance support, while others don't. Because of
+#    that, we are going to create our own support directly calling tor binary
+# 2. tor default config is also placed in different places. Thus we are not
+#    using them yet.
+sub callTor {
+	my $cfg = shift;
+
+	if (not defined($cfg)) {
+		$cfg = "/etc/tor/torrc"
+	}
+
+	# First, check if tor configuration is valid
+	my $output = `sudo tor --runasdaemon 0 -f $cfg --verify-config`;
+	if ($? != 0) {
+		die "[!] Failed to load config $cfg\n$output";
+	}
+
+	print "[.] Config file looks fine\n";
+
+	my %tor      = Nipe::Device -> parseTorConfig($cfg);
+	my $user     = $tor{username};
+	my $daemon   = $tor{is_daemon};
+	my $pid_file = $tor{pid_file};
+
+	# We can have different tor config files to choose, but we don't support
+	# multiple instances of nipe running, otherwise iptable rules may conflict
+	my $run_dir   = "/var/run/nipe";
+	my $lock_file = "$run_dir/instance.lock";
+
+	system ("sudo -u $user cat $lock_file &> /dev/null");
+	if ($? == 0) {
+		die "[!] Running instance of Nipe found, please stop it first\n";
+	}
+
+	system ("umask u=rwx,g=rx,o= ; sudo mkdir -p $run_dir");
+	if ($? != 0) {
+		die "[!] Failed to create $run_dir\n";
+	}
+	system ("sudo chown $user:$user $run_dir");
+
+	# Then, run tor as a non-blocking daemon with a specific pidfile for
+	# future reference when we need to terminate the process, thus we know the
+	# exact tor instance that nipe created
+	system ("sudo tor --runasdaemon $daemon --pidfile $pid_file -f $cfg");
+	if ($? != 0) {
+		die "[!] Failed to run tor\n";
+	}
+
+	# Set a system-wide "lock" file with the same user:group of tor
+	system ("echo \"cat $pid_file > $lock_file\" | sudo -u $user -s");
+
+	return %tor;
+}
+
+sub callIptables {
+	my $tor          = shift;
+	my $dnsPort      = $tor->{dns_port};
+	my $transferPort = $tor->{trans_port};
+	my $network      = $tor->{network};
+	my $username     = $tor->{username};
 	my @table        = ("nat", "filter");
-	my $network      = "10.66.0.0/255.255.0.0";
 
-	my %device = Nipe::Device -> new();
-
-	if (-e "/etc/init.d/tor") {
-		system ("sudo /etc/init.d/tor start > /dev/null");
-	}
-
-	else {
-		system ("sudo systemctl start tor > /dev/null");
-	}
-	
 	foreach my $table (@table) {
 		my $target = "ACCEPT";
 
@@ -29,7 +101,7 @@ sub new {
 
 		system ("sudo iptables -t $table -F OUTPUT");
 		system ("sudo iptables -t $table -A OUTPUT -m state --state ESTABLISHED -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -m owner --uid $device{username} -j $target");
+		system ("sudo iptables -t $table -A OUTPUT -m owner --uid $username -j $target");
 
 		my $matchDnsPort = $dnsPort;
 
@@ -65,8 +137,6 @@ sub new {
 
 	system ("sudo iptables -t filter -A OUTPUT -p udp -j REJECT");
 	system ("sudo iptables -t filter -A OUTPUT -p icmp -j REJECT");
-
-	return true;
 }
 
 1;

--- a/lib/Nipe/Start.pm
+++ b/lib/Nipe/Start.pm
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl
+use strict;
+use warnings;
 
 package Nipe::Start;
 
@@ -24,8 +25,6 @@ sub new {
 	callIptables(\%parsed_cfg);
 	print "[.] Firewall rules set with success\n";
 	print "[.] Nipe initialized with success\n";
-
-	return true;
 }
 
 # Due to non-standard ways to call tor throughout Linux distros from start

--- a/lib/Nipe/Stop.pm
+++ b/lib/Nipe/Stop.pm
@@ -2,6 +2,8 @@
 
 package Nipe::Stop;
 
+use Nipe::Device;
+
 sub new {
 	my @table = ("nat", "filter");
 
@@ -10,12 +12,21 @@ sub new {
 		system ("sudo iptables -t $table -F OUTPUT");
 	}
 
-	if (-e "/etc/init.d/tor") {
-		system ("sudo /etc/init.d/tor stop > /dev/null");
+	# Get Nipe's tor instance PID if running and kill with SIGINT for forced
+	# termination
+	my %device = Nipe::Device -> new();
+	my $user = $device{username};
+	my $lock_file = "/var/run/nipe/instance.lock";
+
+	chomp(my $pid = `sudo -u $user cat $lock_file 2>&1`);
+	if ($? != 0) {
+		print "[.] No instance of tor executed by Nipe was found\n";
 	}
 
 	else {
-		system ("sudo systemctl stop tor > /dev/null");
+		system ("sudo -u $user kill -SIGINT $pid > /dev/null");
+		system ("sudo -u $user rm -f $lock_file > /dev/null");
+		print "[.] Tor instance with PID=$pid terminated\n";
 	}
 
 	return true;

--- a/lib/Nipe/Stop.pm
+++ b/lib/Nipe/Stop.pm
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl
+use strict;
+use warnings;
 
 package Nipe::Stop;
 
@@ -28,8 +29,6 @@ sub new {
 		system ("sudo -u $user rm -f $lock_file > /dev/null");
 		print "[.] Tor instance with PID=$pid terminated\n";
 	}
-
-	return true;
 }
 
 1;

--- a/nipe.pl
+++ b/nipe.pl
@@ -1,8 +1,12 @@
 #!/usr/bin/env perl
 
+use strict;
+use warnings;
 use 5.018;
-use Switch;
+
 use lib "./lib/";
+
+use Switch;
 use Nipe::Stop;
 use Nipe::Start;
 use Nipe::Status;
@@ -20,11 +24,11 @@ sub main {
 		case "start" {
 			my $custom_cfg = undef;
 
-			if ($ARGV[1] eq "-c") {
-				if (length($ARGV[2]) <= 0) {
+			if (defined($ARGV[1]) and $ARGV[1] eq "-c") {
+				if (!defined($ARGV[2])) {
 					print "[!] Invalid argument\n";
 					Nipe::Helper -> new();
-					exit;
+					exit 1;
 				}
 
 				$custom_cfg = $ARGV[2];
@@ -42,19 +46,21 @@ sub main {
 			my $force_cfg = undef;
 			my $custom_cfg = undef;
 
-			if ($ARGV[1] eq "-f") {
-				$force_cfg = 1;
-			}
-
-			elsif ($ARGV[1] eq "-c") {
-				if (length($ARGV[2]) <= 0) {
-					print "[!] Invalid argument\n";
-					Nipe::Helper -> new();
-					exit;
+			if (defined($ARGV[1])) {
+				if ($ARGV[1] eq "-f") {
+					$force_cfg = 1;
 				}
 
-				$force_cfg = 1;
-				$custom_cfg = $ARGV[2];
+				elsif ($ARGV[1] eq "-c") {
+					if (!defined($ARGV[2])) {
+						print "[!] Invalid argument\n";
+						Nipe::Helper -> new();
+						exit 1;
+					}
+
+					$force_cfg = 1;
+					$custom_cfg = $ARGV[2];
+				}
 			}
 
 			Nipe::Install -> new($force_cfg, $custom_cfg);

--- a/nipe.pl
+++ b/nipe.pl
@@ -18,7 +18,19 @@ sub main {
 			Nipe::Stop -> new();
 		}
 		case "start" {
-			Nipe::Start -> new();
+			my $custom_cfg = undef;
+
+			if ($ARGV[1] eq "-c") {
+				if (length($ARGV[2]) <= 0) {
+					print "[!] Invalid argument\n";
+					Nipe::Helper -> new();
+					exit;
+				}
+
+				$custom_cfg = $ARGV[2];
+			}
+
+			Nipe::Start -> new($custom_cfg);
 		}
 		case "status" {
 			Nipe::Status -> new();
@@ -46,6 +58,10 @@ sub main {
 			}
 
 			Nipe::Install -> new($force_cfg, $custom_cfg);
+
+			# Force the user to call "start" command with the new config
+			Nipe::Stop -> new();
+			print "[.] Installation complete\n";
 		}
 
 		Nipe::Helper -> new();


### PR DESCRIPTION
This PR solves two major issues:
#36 : by enabling the `-c` flag on `nipe.pl start`, which accepts custom config files from the user and also by maintaining a "lock file" to follow tor instance started by nipe.
#86 : which help developers not make some known and frequent mistakes.
For each issue there is a single patch, with detailed information on how they were tackled.
