### PR TITLE
ci: update module dependency and command sequence

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -11,8 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run a multi-line script
       run: |
-        sudo apt install -y tor iptables perl
-        sudo cpan install Switch JSON LWP::UserAgent Config::Simple
-        sudo cp .configs/debian-torrc /etc/tor/torrc
-        sudo chmod 644 /etc/tor/torrc
+        sudo apt install -y perl
+        sudo cpan install Switch JSON File::Which Config::Simple
+        perl nipe.pl install -f
         perl nipe.pl status

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
   $ cd nipe
     
   # Install libs and dependencies
-  $ cpan install Switch JSON Config::Simple
+  $ cpan install Switch JSON File::Which Config::Simple
   $ perl nipe.pl install
 ```
 


### PR DESCRIPTION
In the current state of Nipe some changes can be made to the github ci system
in order to get nipe installed. Mostly related to the packages being installed
through system's command vs cpan, and also the process of copying a config
file to tor's default location (via `install` command).

At the same time, remove LWP::UserAgent dependency and add File::Which to
fullfil commit "43e5f4f695a0" requirement.
