### PR TITLE
doc: add information for contributions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,9 +1,28 @@
 # Contributing to the Nipe!
 
-## License
+## Branches
 
-By opening a pull request in this repository, you agree to provide your work under the [project license](../LICENSE.md).
+The `master` branch is used only for holding released code of the project. Any
+new feature or bugfix **must** be opened against `develop` branch, where some
+additional testing is performed before the code lands `master`.
+
+## Testing
+
+For every new feature, please, submit in the same PR a testing code (under
+`t/` folder) to cover that completely. Make sure to expand and cover the
+added/replaced code as much as possible.
+
+In case it's a functional bugfix (not a typo, commentary, whitespace, ...
+issue), make sure to check why the test code didn't trigger the bug before
+and, if possible, update the test.
 
 ## Great Re-Writings
 
-Open a discussion issue before you begin. So we can listen to what you have to say, and we can provide a referral if it will be worth changing big parts of the project.
+Open a discussion issue before you begin. So we can listen to what you have to
+say, and we can provide a referral if it will be worth changing big parts of
+the project.
+
+## License
+
+By opening a pull request in this repository, you agree to provide your work
+under the [project license](../LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@
 ```
   COMMAND          FUNCTION
   install          Install dependencies
-  	  -f           Overwrite Tor config file in /etc/tor/torrc
-      -c <file>    Specify a custom location to install Tors config file
+    -f             Overwrite Tor config file in /etc/tor/torrc
+    -c <file>      Specify a custom location to install Tors config file
   start            Start routing
   stop             Stop routing
   restart          Restart the Nipe process


### PR DESCRIPTION
Added some small infos for new comers contribution and a small typo fix in
README file. Nothing functional, only documentation.

I also think we should stablish a default coding style (max line length and tab vs spaces, at least), but it can come later.

This PR is part of issue #81 .