### PR TITLE
Replace TOR with Tor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@
 
 ### How it works
 ```
-  The TOR project allows users to surf the Internet, chat and send instant messages anonymously 
+  The Tor project allows users to surf the Internet, chat and send instant messages anonymously 
   through its own mechanism. It is used by a wide variety of people, companies and organizations, 
-  both for lawful activities and for other illicit purposes. TOR is already gone and is used for 
+  both for lawful activities and for other illicit purposes. Tor is already gone and is used for 
   example by criminal companies, hacking groups, intelligence agencies and even ordinary users who care
   about privacy in the digital world. 
   
-  Nipe is a engine, developed in Perl, that aims to make the TOR network your default network gateway. 
-  Through Nipe, we can directly route traffic from our computer to the TOR network through which you can 
+  Nipe is a engine, developed in Perl, that aims to make the Tor network your default network gateway. 
+  Through Nipe, we can directly route traffic from our computer to the Tor network through which you can 
   surf the Internet having a more formidable stance on privacy and anonymity in cyberspace.
   
   Currently, only IPv4 is supported by Nipe, but we are working on a solution to add IPv6 support. 
   Also, only traffic other than DNS requests destined for local and/or loopback addresses is not 
-  trafficked through the TOR. All non-local UDP/ICMP traffic is also blocked by the TOR project.
+  trafficked through the Tor. All non-local UDP/ICMP traffic is also blocked by the Tor project.
 ```
 
 


### PR DESCRIPTION
### What was a problem?

TOR isn't how The Onion Routing written by Tor Project team and Wikipedia. And should be TOR replaced with Tor.

### How this PR fixes the problem?

This PR replaces TOR with Tor in README.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)