### PR TITLE
Implementing new code to dont remove orignal torrc of user

### DIFF
--- a/.github/workflows/audit-code.yml
+++ b/.github/workflows/audit-code.yml
@@ -10,4 +10,4 @@ jobs:
     - name: Audit code
       run: |
         sudo apt install -y libpath-iterator-rule-perl libtest-perl-critic-perl 
-        curl -L https://gist.githubusercontent.com/GouveaHeitor/b7df5c12c0ba49662b32918d6fa3dec1/raw/72c60bc46796153ce1b874d201d5ffa4e761b519/audit.pl >> audit.pl && perl audit.pl
+        curl https://gist.githubusercontent.com/GouveaHeitor/b7df5c12c0ba49662b32918d6fa3dec1/raw/72c60bc46796153ce1b874d201d5ffa4e761b519/audit.pl | perl

--- a/lib/Nipe/Engine/Start.pm
+++ b/lib/Nipe/Engine/Start.pm
@@ -13,6 +13,8 @@ sub new {
 
 	my %device = Nipe::Utils::Device -> new();
 
+	system ("sudo tor -f .configs/debian-torrc > /dev/null");
+
 	if (-e "/etc/init.d/tor") {
 		$startTor = "sudo /etc/init.d/tor start > /dev/null";
 	}

--- a/lib/Nipe/Engine/Start.pm
+++ b/lib/Nipe/Engine/Start.pm
@@ -13,12 +13,11 @@ sub new {
 
 	my %device = Nipe::Utils::Device -> new();
 
-	system ("sudo tor -f .configs/debian-torrc > /dev/null");
-
 	if (-e "/etc/init.d/tor") {
 		$startTor = "sudo /etc/init.d/tor start > /dev/null";
 	}
 
+	system ("sudo tor -f .configs/$device{distribution}-torrc > /dev/null");
 	system ($startTor);
 	
 	foreach my $table (@table) {

--- a/lib/Nipe/Utils/Install.pm
+++ b/lib/Nipe/Utils/Install.pm
@@ -8,29 +8,21 @@ sub new {
 	my %device  = Nipe::Utils::Device -> new();
 	my $stopTor = "sudo systemctl stop tor";
 
-	system ("sudo mkdir -p /etc/tor/");
-
 	if ($device{distribution} eq "debian") {
 		system ("sudo apt-get install -y tor iptables");
-		system ("sudo cp .configs/debian-torrc /etc/tor/torrc");
 	}
 	
 	elsif ($device{distribution} eq "fedora") {
 		system ("sudo dnf install -y tor iptables");
-		system ("sudo cp .configs/fedora-torrc /etc/tor/torrc");
 	}
 
 	elsif ($device{distribution} eq "centos") {
 		system ("sudo yum -y install epel-release tor iptables");
-		system ("sudo cp .configs/centos-torrc /etc/tor/torrc");
 	}
 
 	else {
 		system ("sudo pacman -S --noconfirm -S tor iptables");
-		system ("sudo cp .configs/arch-torrc /etc/tor/torrc");
 	}
-
-	system ("sudo chmod 644 /etc/tor/torrc");
 
 	if (-e "/etc/init.d/tor") {
 		$stopTor = "sudo /etc/init.d/tor stop > /dev/null";


### PR DESCRIPTION
### What was a problem?

Previously, Nipe had its own torrc file and it replaced the original Tor with this one. Which is somewhat invasive...

### How this PR fixes the problem?

Through the tor utility, I am using the "-f" option to direct the Nipe configuration file.

### Check lists 

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)