### PR TITLE
Fix Archlinux dependencies installation

### DIFF
--- a/lib/Nipe/Utils/Install.pm
+++ b/lib/Nipe/Utils/Install.pm
@@ -21,7 +21,7 @@ sub new {
 	}
 
 	else {
-		system ("sudo pacman -S --noconfirm -S tor iptables");
+		system ("sudo pacman -S --noconfirm tor iptables");
 	}
 
 	if (-e "/etc/init.d/tor") {


### PR DESCRIPTION
### What was a problem?

```
[!] ERROR: this command could not be run
```
During dependencies installation

### How this PR fixes the problem?

By fixing arch depend installation command

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)