### PR TITLE
Void Linux compatibility

### DIFF
--- a/.configs/void-torrc
+++ b/.configs/void-torrc
@@ -1,0 +1,12 @@
+DataDirectory /var/lib/tor
+Log notice syslog
+RunAsDaemon 1
+
+User tor
+
+ClientOnly 1
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
+DNSPort   9061
+
+VirtualAddrNetwork 10.66.0.0/16
+AutomapHostsOnResolve 1

--- a/lib/Nipe/Engine/Start.pm
+++ b/lib/Nipe/Engine/Start.pm
@@ -5,21 +5,24 @@ use warnings;
 use Nipe::Utils::Device;
 
 sub new {
+	my %device  = Nipe::Utils::Device -> new();
 	my $dnsPort      = "9061";
 	my $transferPort = "9051";
 	my @table        = ("nat", "filter");
 	my $network      = "10.66.0.0/255.255.0.0";
-	my $startTor     = "sudo systemctl start tor";
+	my $startTor     = "systemctl start tor";
 
-	my %device = Nipe::Utils::Device -> new();
-
-	if (-e "/etc/init.d/tor") {
-		$startTor = "sudo /etc/init.d/tor start > /dev/null";
+	if ($device{distribution} eq "void") {
+		$startTor = "sv start tor";
 	}
 
-	system ("sudo tor -f .configs/$device{distribution}-torrc > /dev/null");
+	elsif (-e "/etc/init.d/tor") {
+		$startTor = "/etc/init.d/tor start > /dev/null";
+	}
+
+	system ("tor -f .configs/$device{distribution}-torrc > /dev/null");
 	system ($startTor);
-	
+
 	foreach my $table (@table) {
 		my $target = "ACCEPT";
 
@@ -27,9 +30,9 @@ sub new {
 			$target = "RETURN";
 		}
 
-		system ("sudo iptables -t $table -F OUTPUT");
-		system ("sudo iptables -t $table -A OUTPUT -m state --state ESTABLISHED -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -m owner --uid $device{username} -j $target");
+		system ("iptables -t $table -F OUTPUT");
+		system ("iptables -t $table -A OUTPUT -m state --state ESTABLISHED -j $target");
+		system ("iptables -t $table -A OUTPUT -m owner --uid $device{username} -j $target");
 
 		my $matchDnsPort = $dnsPort;
 
@@ -38,33 +41,33 @@ sub new {
 			$matchDnsPort = "53";
 		}
 
-		system ("sudo iptables -t $table -A OUTPUT -p udp --dport $matchDnsPort -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -p tcp --dport $matchDnsPort -j $target");
+		system ("iptables -t $table -A OUTPUT -p udp --dport $matchDnsPort -j $target");
+		system ("iptables -t $table -A OUTPUT -p tcp --dport $matchDnsPort -j $target");
 
 		if ($table eq "nat") {
 			$target = "REDIRECT --to-ports $transferPort";
 		}
 
-		system ("sudo iptables -t $table -A OUTPUT -d $network -p tcp -j $target");
+		system ("iptables -t $table -A OUTPUT -d $network -p tcp -j $target");
 
 		if ($table eq "nat") {
 			$target = "RETURN";
 		}
 
-		system ("sudo iptables -t $table -A OUTPUT -d 127.0.0.1/8    -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -d 192.168.0.0/16 -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -d 172.16.0.0/12  -j $target");
-		system ("sudo iptables -t $table -A OUTPUT -d 10.0.0.0/8     -j $target");
+		system ("iptables -t $table -A OUTPUT -d 127.0.0.1/8    -j $target");
+		system ("iptables -t $table -A OUTPUT -d 192.168.0.0/16 -j $target");
+		system ("iptables -t $table -A OUTPUT -d 172.16.0.0/12  -j $target");
+		system ("iptables -t $table -A OUTPUT -d 10.0.0.0/8     -j $target");
 
 		if ($table eq "nat") {
 			$target = "REDIRECT --to-ports $transferPort";
 		}
 
-		system ("sudo iptables -t $table -A OUTPUT -p tcp -j $target");
+		system ("iptables -t $table -A OUTPUT -p tcp -j $target");
 	}
 
-	system ("sudo iptables -t filter -A OUTPUT -p udp -j REJECT");
-	system ("sudo iptables -t filter -A OUTPUT -p icmp -j REJECT");
+	system ("iptables -t filter -A OUTPUT -p udp -j REJECT");
+	system ("iptables -t filter -A OUTPUT -p icmp -j REJECT");
 
 	return 1;
 }

--- a/lib/Nipe/Engine/Stop.pm
+++ b/lib/Nipe/Engine/Stop.pm
@@ -2,18 +2,24 @@ package Nipe::Engine::Stop;
 
 use strict;
 use warnings;
+use Nipe::Utils::Device;
 
 sub new {
+	my %device  = Nipe::Utils::Device -> new();
 	my @table   = ("nat", "filter");
-	my $stopTor = "sudo systemctl stop tor";
+	my $stopTor = "systemctl stop tor";
+
+	if ($device{distribution} eq "void") {
+	    $stopTor = "sv stop tor";
+	}
 
 	foreach my $table (@table) {
-		system ("sudo iptables -t $table -F OUTPUT");
-		system ("sudo iptables -t $table -F OUTPUT");
+		system ("iptables -t $table -F OUTPUT");
+		system ("iptables -t $table -F OUTPUT");
 	}
 
 	if (-e "/etc/init.d/tor") {
-		$stopTor = "sudo /etc/init.d/tor stop > /dev/null";
+		$stopTor = "/etc/init.d/tor stop > /dev/null";
 	}
 
 	system ($stopTor);

--- a/lib/Nipe/Utils/Device.pm
+++ b/lib/Nipe/Utils/Device.pm
@@ -6,22 +6,27 @@ use Config::Simple;
 
 sub new {
 	my $config    = Config::Simple -> new('/etc/os-release');
-	my $id_like   = $config -> param('ID_LIKE');
+	my $id_like   = $config -> param('ID_LIKE') || "";
 	my $id_distro = $config -> param('ID');
 
 	my %device = (
 		"username" => "",
 		"distribution"  => ""
 	);
-	
+
 	if (($id_like =~ /[F,f]edora/) || ($id_distro =~ /[F,f]edora/)) {
 		$device{username} = "toranon";
 		$device{distribution} = "fedora";
 	}
-	
+
 	elsif (($id_like =~ /[A,a]rch/) || ($id_like =~ /[C,c]entos/) || ($id_distro =~ /[A,a]rch/) || ($id_distro =~ /[C,c]entos/)) {
 		$device{username} = "tor";
 		$device{distribution} = "arch";
+	}
+
+	elsif ($id_distro =~ /[V,v]oid/) {
+		$device{username} = "tor";
+		$device{distribution} = "void";
 	}
 
 	else {

--- a/lib/Nipe/Utils/Install.pm
+++ b/lib/Nipe/Utils/Install.pm
@@ -6,28 +6,33 @@ use Nipe::Utils::Device;
 
 sub new {
 	my %device  = Nipe::Utils::Device -> new();
-	my $stopTor = "sudo systemctl stop tor";
+	my $stopTor = "systemctl stop tor";
 
 	if ($device{distribution} eq "debian") {
-		system ("sudo apt-get install -y tor iptables");
+		system ("apt-get install -y tor iptables");
 	}
-	
+
 	elsif ($device{distribution} eq "fedora") {
-		system ("sudo dnf install -y tor iptables");
+		system ("dnf install -y tor iptables");
 	}
 
 	elsif ($device{distribution} eq "centos") {
-		system ("sudo yum -y install epel-release tor iptables");
+		system ("yum -y install epel-release tor iptables");
+	}
+
+	elsif ($device{distribution} eq "void") {
+		system ("xbps-install -y tor iptables");
+		$stopTor = "sv stop tor > /dev/null";
 	}
 
 	else {
-		system ("sudo pacman -S --noconfirm tor iptables");
+		system ("pacman -S --noconfirm tor iptables");
 	}
 
 	if (-e "/etc/init.d/tor") {
-		$stopTor = "sudo /etc/init.d/tor stop > /dev/null";
+		$stopTor = "/etc/init.d/tor stop > /dev/null";
 	}
-	
+
 	system ($stopTor);
 
 	return 1;

--- a/nipe.pl
+++ b/nipe.pl
@@ -13,11 +13,12 @@ use Nipe::Utils::Helper;
 use Nipe::Utils::Install;
 
 sub main {
-	my $argument = $ARGV[0];
+	die "$0 must be run as root" if $> != 0;
 
+	my $argument = $ARGV[0];
 	if ($argument) {
 		my $commands = {
-			stop => "Nipe::Engine::Stop", 
+			stop => "Nipe::Engine::Stop",
 			start => "Nipe::Engine::Start",
 			status => "Nipe::Utils::Status",
 			restart => "Nipe::Engine::Restart",
@@ -32,14 +33,14 @@ sub main {
 				print $exec;
 			}
 		}
-		
+
 		catch {
   			print "\n[!] ERROR: this command could not be run\n\n";
 		};
 
 		return 1;
 	}
-	
+
 	return print Nipe::Utils::Helper -> new();
 }
 


### PR DESCRIPTION
### What was a problem?

There was a problem running nipe.pl on [Void Linux](https://voidlinux.org/)
Void Linux uses [runit](http://smarden.org/runit/index.html) (a cross-platform Unix init scheme) instead of systemd.

```
./nipe.pl start
Use of uninitialized value $id_like in pattern match (m//) at lib/Nipe/Utils/Device.pm line 17.
Use of uninitialized value $id_like in pattern match (m//) at lib/Nipe/Utils/Device.pm line 22.
Use of uninitialized value $id_like in pattern match (m//) at lib/Nipe/Utils/Device.pm line 22.
Password:
sudo: systemctl: command not found
iptables v1.8.5 (legacy): owner: Bad value for "--uid-owner" option: "debian-tor"
Try `iptables -h' or 'iptables --help' for more information.
iptables v1.8.5 (legacy): owner: Bad value for "--uid-owner" option: "debian-tor"
Try `iptables -h' or 'iptables --help' for more information.

```

### How this PR fixes the problem?

- checks if nipe.pl is running on Void Linux in `lib/Nipe/Utils/Device.pm`
- use **xbps-install** to install dependencies(tor, iptables)  on Void Linux
- use **[sv](http://smarden.org/runit/sv.8.html)** instead of **systemctl** on Void Linux

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)

### Additional Comments

- check if user running nipe.pl is root
- get rid of `sudo` all over the code.