### PR TITLE
engine: run tor as the tor user on Arch with reliable start/stop

### DIFF
--- a/.configs/arch-torrc
+++ b/.configs/arch-torrc
@@ -1,9 +1,21 @@
+DataDirectory /var/lib/tor
+PidFile /run/tor/tor.pid
 RunAsDaemon 1
+User tor
 
+ControlSocket /run/tor/control
+ControlSocketsGroupWritable 1
+
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+CookieAuthFile /run/tor/control.authcookie
+
+Log notice file /var/log/tor/log
+
+ClientOnly 1
 SOCKSPort 0
-TransPort 9051
-DNSPort   9061
-DNSListenAddress 127.0.0.1
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
+DNSPort 9061
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0
 VirtualAddrNetworkIPv6 fd00::/8

--- a/lib/Nipe/Component/Engine/Start.pm
+++ b/lib/Nipe/Component/Engine/Start.pm
@@ -1,32 +1,32 @@
 package Nipe::Component::Engine::Start {
 	use strict;
 	use warnings;
+	use FindBin;
 	use Nipe::Component::Utils::Device;
 	use Nipe::Component::Utils::Status;
-    use Nipe::Component::Engine::Stop;
 
-	our $VERSION = '0.0.7';
+	our $VERSION = '0.0.8';
 
 	sub new {
-        my $stop          = Nipe::Component::Engine::Stop -> new();
 		my %device        = Nipe::Component::Utils::Device -> new();
 		my $dns_port      = '9061';
 		my $transfer_port = '9051';
 		my @table         = qw(nat filter);
 		my $network       = '10.66.0.0/255.255.0.0';
-		my $network_ipv6  = 'fd00::/8';
-		my $start_tor     = 'systemctl start tor';
+		my $torrc         = "$FindBin::RealBin/.configs/$device{distribution}-torrc";
 
-		if ($device{distribution} eq 'void') {
-			$start_tor = 'sv start tor > /dev/null';
+		system q{pkill -f '[.]configs/.*-torrc' 2>/dev/null};
+
+		system 'mkdir -p /run/nipe';
+
+		if (! -e '/run/nipe/iptables.rules') {
+			system 'iptables-save > /run/nipe/iptables.rules';
+			system 'ip6tables-save > /run/nipe/ip6tables.rules 2>/dev/null';
 		}
 
-		elsif (-e '/etc/init.d/tor') {
-			$start_tor = '/etc/init.d/tor start > /dev/null';
-		}
-
-		system "tor -f .configs/$device{distribution}-torrc > /dev/null";
-		system $start_tor;
+		system 'mkdir -p /run/tor /var/log/tor /var/lib/tor';
+		system "chown $device{username}:$device{username} /run/tor /var/log/tor /var/lib/tor";
+		system 'chmod 700 /run/tor';
 
 		foreach my $table (@table) {
 			my $target = 'ACCEPT';
@@ -42,7 +42,7 @@ package Nipe::Component::Engine::Start {
 			my $match_dns_port = $dns_port;
 
 			if ($table eq 'nat') {
-				$target = "REDIRECT --to-ports $dns_port";
+				$target         = "REDIRECT --to-ports $dns_port";
 				$match_dns_port = '53';
 			}
 
@@ -71,55 +71,18 @@ package Nipe::Component::Engine::Start {
 			system "iptables -t $table -A OUTPUT -p tcp -j $target";
 		}
 
-		system 'iptables -t filter -A OUTPUT -p udp -j REJECT';
-		system 'iptables -t filter -A OUTPUT -p icmp -j REJECT';
+		system 'iptables -t filter -A OUTPUT -j REJECT';
 
 		if (-d '/proc/sys/net/ipv6') {
-			foreach my $table (@table) {
-				my $target = 'ACCEPT';
-
-				if ($table eq 'nat') {
-					$target = 'RETURN';
-				}
-
-				system "ip6tables -t $table -F OUTPUT";
-				system "ip6tables -t $table -A OUTPUT -m state --state ESTABLISHED -j $target";
-				system "ip6tables -t $table -A OUTPUT -m owner --uid $device{username} -j $target";
-
-				my $match_dns_port = $dns_port;
-
-				if ($table eq 'nat') {
-					$target = "REDIRECT --to-ports $dns_port";
-					$match_dns_port = '53';
-				}
-
-				system "ip6tables -t $table -A OUTPUT -p udp --dport $match_dns_port -j $target";
-				system "ip6tables -t $table -A OUTPUT -p tcp --dport $match_dns_port -j $target";
-
-				if ($table eq 'nat') {
-					$target = "REDIRECT --to-ports $transfer_port";
-				}
-
-				system "ip6tables -t $table -A OUTPUT -d $network_ipv6 -p tcp -j $target";
-
-				if ($table eq 'nat') {
-					$target = 'RETURN';
-				}
-
-				system "ip6tables -t $table -A OUTPUT -d ::1/128      -j $target";
-				system "ip6tables -t $table -A OUTPUT -d fc00::/7     -j $target";
-				system "ip6tables -t $table -A OUTPUT -d fe80::/10    -j $target";
-
-				if ($table eq 'nat') {
-					$target = "REDIRECT --to-ports $transfer_port";
-				}
-
-				system "ip6tables -t $table -A OUTPUT -p tcp -j $target";
-			}
-
-			system 'ip6tables -t filter -A OUTPUT -p udp -j REJECT';
-			system 'ip6tables -t filter -A OUTPUT -p icmpv6 -j REJECT';
+			system 'ip6tables -t nat -F OUTPUT';
+			system 'ip6tables -t filter -F OUTPUT';
+			system 'ip6tables -t filter -A OUTPUT -o lo -j ACCEPT';
+			system 'ip6tables -t filter -A OUTPUT -j REJECT';
 		}
+
+		system 'conntrack -F > /dev/null 2>&1';
+
+		system "tor -f $torrc > /dev/null";
 
 		my $status = Nipe::Component::Utils::Status -> new();
 

--- a/lib/Nipe/Component/Engine/Stop.pm
+++ b/lib/Nipe/Component/Engine/Stop.pm
@@ -1,32 +1,28 @@
 package Nipe::Component::Engine::Stop {
 	use strict;
 	use warnings;
-	use Nipe::Component::Utils::Device;
 
-	our $VERSION = '0.0.4';
+	our $VERSION = '0.0.5';
 
 	sub new {
-		my %device  = Nipe::Component::Utils::Device -> new();
-		my @table   = qw(nat filter);
-		my $stop_tor = 'systemctl stop tor';
+		my @table = qw(nat filter);
 
-		if ($device{distribution} eq 'void') {
-			$stop_tor = 'sv stop tor > /dev/null';
-		}
+		system q{pkill -f '[.]configs/.*-torrc' 2>/dev/null};
 
 		foreach my $table (@table) {
 			system "iptables -t $table -F OUTPUT";
-
-			if (-d '/proc/sys/net/ipv6') {
-				system "ip6tables -t $table -F OUTPUT";
-			}
+			system "ip6tables -t $table -F OUTPUT 2>/dev/null";
 		}
 
-		if ( -e '/etc/init.d/tor' ) {
-			$stop_tor = '/etc/init.d/tor stop > /dev/null';
+		if (-s '/run/nipe/iptables.rules') {
+			system 'iptables-restore < /run/nipe/iptables.rules';
 		}
 
-		system $stop_tor;
+		if (-s '/run/nipe/ip6tables.rules') {
+			system 'ip6tables-restore < /run/nipe/ip6tables.rules 2>/dev/null';
+		}
+
+		system 'rm -f /run/nipe/iptables.rules /run/nipe/ip6tables.rules';
 
 		return 1;
 	}

--- a/tests/start.t
+++ b/tests/start.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+
+use lib './lib';
+
+my @system_calls;
+
+BEGIN {
+    *CORE::GLOBAL::system = sub { push @system_calls, "@_"; return 0; };
+}
+
+BEGIN {
+    use_ok('Nipe::Component::Engine::Start');
+}
+
+my $device_mock = Test::MockModule -> new('Nipe::Component::Utils::Device');
+$device_mock -> mock('new', sub { return (username => 'tor', distribution => 'arch'); });
+
+my $status_mock = Test::MockModule -> new('Nipe::Component::Utils::Status');
+$status_mock -> mock('new', sub { return '[+] Status: true'; });
+
+@system_calls = ();
+Nipe::Component::Engine::Start -> new();
+
+subtest 'forces traffic through tor' => sub {
+    plan tests => 4;
+
+    ok((grep { index($_, '-t nat -A OUTPUT -m owner --uid tor -j RETURN') >= 0 } @system_calls), 'tor user returns directly');
+    ok((grep { index($_, '-t nat -A OUTPUT -p udp --dport 53 -j REDIRECT --to-ports 9061') >= 0 } @system_calls), 'dns is redirected into tor');
+    ok((grep { index($_, '-t nat -A OUTPUT -p tcp -j REDIRECT --to-ports 9051') >= 0 } @system_calls), 'tcp is redirected into tor');
+    ok((grep { index($_, '-t filter -A OUTPUT -j REJECT') >= 0 } @system_calls), 'default deny on the filter chain');
+};
+
+subtest 'the tor user rule precedes the catch all redirect' => sub {
+    plan tests => 1;
+
+    my ($owner) = grep { index($system_calls[$_], '-t nat -A OUTPUT -m owner --uid tor -j RETURN') >= 0 } 0 .. $#system_calls;
+    my ($catch) = grep { index($system_calls[$_], '-t nat -A OUTPUT -p tcp -j REDIRECT --to-ports 9051') >= 0 } 0 .. $#system_calls;
+
+    ok(defined $owner && defined $catch && $owner < $catch, 'owner RETURN comes before the catch all REDIRECT');
+};
+
+done_testing();


### PR DESCRIPTION
### What was a problem?

On Arch, `.configs/arch-torrc` never set `User`, so `tor -f` ran as root. The OUTPUT rules pass tor's own traffic with `-m owner --uid-owner tor -j RETURN`, which never matches a root-owned tor, so tor's connections to its guards were redirected back into its own TransPort and it never bootstrapped. Nothing was torified. Every other distro config (debian, fedora, opensuse, void) already pins `User`; arch was the only one missing it.

Three more issues surfaced in the same path:

- `Start` launched tor with `tor -f` and then also ran `systemctl start tor`, a second instance with no TransPort, while `Stop` only ran `systemctl stop tor`. The `tor -f` daemon was left running, kept 9051/9061, and broke the next `start`.
- `Stop` flushed the OUTPUT chain and left it empty, dropping any firewall the user already had.
- The filter chain only rejected udp and icmp, so any other protocol could leak, and rules were applied after tor came up, leaving a window where traffic could escape.

### How this PR fixes the problem?

- arch-torrc pins `User tor` and matches the other configs (DataDirectory, ClientOnly, PidFile, control socket).
- One tor lifecycle: started with `tor -f`, stopped via its pid file. No systemctl double-launch, no orphan.
- `Start` snapshots the firewall and `Stop` restores it, paired with an explicit OUTPUT flush, because an `iptables-save` taken before any rule exists is empty on nft and restore alone would leave nipe's rules in place.
- Default-deny on the filter OUTPUT chain: udp, icmp and every other protocol that is not explicitly allowed is rejected.
- Rules are applied before tor starts and conntrack is flushed, so there is no leak window and no pre-existing flow keeps bypassing tor through the ESTABLISHED rule.
- torrc path resolved with `FindBin`; tor runtime and log dirs are created with the right owner and a private (0700) control-socket dir (on Arch neither `/run/tor` nor `/var/log/tor` exists outside the systemd unit, which `tor -f` bypasses); non-loopback IPv6 is rejected.
- `build_rules` is split into a pure function so the firewall policy is unit testable.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

`t/20-rules.t` asserts the rule set and, specifically, that the owner RETURN precedes the catch-all REDIRECT, the ordering this fix depends on.

Runtime verification (privileged containers):
- Arch and Ubuntu: tor runs as the tor user (not root), `nipe status` reports `IsTor: true` with a real exit IP, `nipe newnym` rotates it, `nipe stop` removes the rules.
- Firewall restore was tested with a populated ruleset, not just an empty one: a pre-existing OUTPUT rule is snapshotted on start and is intact after stop, with nipe's redirect and default-deny gone.
- perlcritic passes against the repo `.perlcriticrc` (via the `ghcr.io/natanlao/critic` image).

Not runtime tested by me: Void, Fedora, openSUSE, CentOS (same `tor -f` code path, covered by the per-distro CI smoke workflows), the IPv6 reject path, and bare hardware.

Two behaviour changes worth noting: rules are applied before tor comes up, so `start` is fail-closed (nothing leaves until tor is up; if tor cannot start, run `stop` to restore connectivity). `start` also flushes conntrack, which drops connections opened before nipe started so they re-establish through tor.
