### PR TITLE
detect: match the distro ID before the ID_LIKE family

### DIFF
--- a/lib/Nipe/Component/Utils/Device.pm
+++ b/lib/Nipe/Component/Utils/Device.pm
@@ -3,51 +3,33 @@ package Nipe::Component::Utils::Device {
 	use warnings;
 	use Config::Simple;
 
-	our $VERSION = '0.0.4';
+	our $VERSION = '0.0.5';
 
 	sub new {
 		my $config    = Config::Simple -> new('/etc/os-release');
 		my $id_like   = $config -> param('ID_LIKE') || q{};
-		my $id_distro = $config -> param('ID');
-
-		my %device = (
-			'username'     => 'debian-tor',
-			'distribution' => 'debian'
-		);
+		my $id_distro = $config -> param('ID')      || q{};
 
 		my @distributions = (
-			{
-				pattern      => qr/[F,f]edora/xsm,
-				username     => 'toranon',
-				distribution => 'fedora',
-			},
-			{
-				pattern      => qr/[A,a]rch|[C,c]entos/xsm,
-				username     => 'tor',
-				distribution => 'arch',
-			},
-			{
-				pattern      => qr/[V,v]oid/xsm,
-				username     => 'tor',
-				distribution => 'void',
-			},
-			{
-				pattern      => qr/[S,s]use|[O,o]pen[S,s]use/xsm,
-				username     => 'tor',
-				distribution => 'opensuse',
-			},
+			{ pattern => qr/[Ff]edora/xsm,                  username => 'toranon', distribution => 'fedora'   },
+			{ pattern => qr/[Cc]entos|[Rr]hel|[Rr]ocky/xsm, username => 'tor',     distribution => 'centos'   },
+			{ pattern => qr/[Aa]rch|[Mm]anjaro/xsm,         username => 'tor',     distribution => 'arch'     },
+			{ pattern => qr/[Vv]oid/xsm,                    username => 'tor',     distribution => 'void'     },
+			{ pattern => qr/[Ss]use/xsm,                    username => 'tor',     distribution => 'opensuse' },
 		);
 
-		for my $distro (@distributions) {
-			if (($id_like =~ $distro -> {pattern}) || ($id_distro =~ $distro -> {pattern})) {
-				$device{username}     = $distro -> {username};
-				$device{distribution} = $distro -> {distribution};
-
-				last;
+		foreach my $source ($id_distro, $id_like) {
+			foreach my $distro (@distributions) {
+				if ($source =~ $distro -> {pattern}) {
+					return (
+						username     => $distro -> {username},
+						distribution => $distro -> {distribution},
+					);
+				}
 			}
 		}
 
-		return %device;
+		return (username => 'debian-tor', distribution => 'debian');
 	}
 }
 

--- a/tests/device.t
+++ b/tests/device.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+
+use lib './lib';
+
+BEGIN {
+    use_ok('Nipe::Component::Utils::Device');
+}
+
+my %osrelease;
+
+my $config_mock = Test::MockModule -> new('Config::Simple');
+$config_mock -> mock('new', sub { return bless {}, 'Config::Simple'; });
+$config_mock -> mock('param', sub {
+    my ($self, $key) = @_;
+    return $osrelease{$key};
+});
+
+my @cases = (
+    [ 'arch',          q{},             'tor',        'arch'     ],
+    [ 'manjaro',       'arch',          'tor',        'arch'     ],
+    [ 'debian',        q{},             'debian-tor', 'debian'   ],
+    [ 'ubuntu',        'debian',        'debian-tor', 'debian'   ],
+    [ 'fedora',        q{},             'toranon',    'fedora'   ],
+    [ 'centos',        'rhel fedora',   'tor',        'centos'   ],
+    [ 'rhel',          'fedora',        'tor',        'centos'   ],
+    [ 'void',          q{},             'tor',        'void'     ],
+    [ 'opensuse-leap', 'suse opensuse', 'tor',        'opensuse' ],
+);
+
+foreach my $case (@cases) {
+    my ($id, $like, $user, $distro) = @{$case};
+
+    subtest "$id resolves to $distro" => sub {
+        plan tests => 2;
+
+        %osrelease = (ID => $id, ID_LIKE => $like);
+        my %device = Nipe::Component::Utils::Device -> new();
+
+        is($device{username},     $user,   "user is $user");
+        is($device{distribution}, $distro, "distribution is $distro");
+    };
+}
+
+subtest 'centos is not misdetected as fedora through ID_LIKE' => sub {
+    plan tests => 1;
+
+    %osrelease = (ID => 'centos', ID_LIKE => 'rhel fedora');
+    my %device = Nipe::Component::Utils::Device -> new();
+
+    is($device{distribution}, 'centos', 'centos wins over fedora');
+};
+
+done_testing();


### PR DESCRIPTION
### What was a problem?

`Device::new` matched each distro pattern against `ID` and `ID_LIKE` together in one loop, with `fedora` first. CentOS Stream ships `ID=centos` with `ID_LIKE="rhel fedora"`, so the fedora pattern matched on `ID_LIKE` and CentOS was detected as fedora. The `centos` branch in `Network::Install` (`yum ...`) and `.configs/centos-torrc` were never reachable. The `[A,a]rch` style character classes also matched a stray comma.

### How this PR fixes the problem?

Match the specific `ID` first, then fall back to the `ID_LIKE` family, so the exact distro wins. centos/rhel/rocky/alma resolve to the centos profile, arch/manjaro/endeavour to arch, and unknown distros still fall back to debian. `detect` is split from the os-release read so it is pure, and a space separated `ID_LIKE` that Config::Simple returns as an array is flattened back to a string first.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

`t/10-device.t` covers the mapping table, including the CentOS via ID_LIKE regression and the debian fallback.
