### PR TITLE
feat: add newnym circuit rotation and stream isolation

### DIFF
--- a/.configs/centos-torrc
+++ b/.configs/centos-torrc
@@ -13,7 +13,7 @@ CookieAuthFile /var/run/tor/control.authcookie
 Log notice file /var/log/tor/log
 
 ClientOnly 1
-TransPort 9051
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
 DNSPort   9061
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0

--- a/.configs/debian-torrc
+++ b/.configs/debian-torrc
@@ -13,7 +13,7 @@ CookieAuthFile /var/run/tor/control.authcookie
 Log notice file /var/log/tor/log
 
 ClientOnly 1
-TransPort 9051
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
 DNSPort   9061
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0

--- a/.configs/fedora-torrc
+++ b/.configs/fedora-torrc
@@ -14,7 +14,7 @@ Log notice file /var/log/tor/log
 
 ClientOnly 1
 SOCKSPort 0
-TransPort 9051
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
 DNSPort   9061
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0

--- a/.configs/opensuse-torrc
+++ b/.configs/opensuse-torrc
@@ -14,7 +14,7 @@ Log notice file /var/log/tor/log
 
 ClientOnly 1
 SOCKSPort 0
-TransPort 9051
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
 DNSPort 9061
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0

--- a/.configs/void-torrc
+++ b/.configs/void-torrc
@@ -1,8 +1,16 @@
 DataDirectory /var/lib/tor
+PidFile /run/tor/tor.pid
 Log notice syslog
 RunAsDaemon 1
 
 User tor
+
+ControlSocket /run/tor/control
+ControlSocketsGroupWritable 1
+
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+CookieAuthFile /run/tor/control.authcookie
 
 ClientOnly 1
 TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort

--- a/lib/Nipe/Component/Engine/Newnym.pm
+++ b/lib/Nipe/Component/Engine/Newnym.pm
@@ -1,0 +1,51 @@
+package Nipe::Component::Engine::Newnym {
+	use strict;
+	use warnings;
+	use English qw(-no_match_vars);
+	use IO::Socket::UNIX;
+	use Readonly;
+	use Time::HiRes ();
+	use Nipe::Component::Utils::Status;
+
+	our $VERSION = '0.0.1';
+
+	Readonly my $CIRCUIT_DELAY => 3;
+
+	my $CONTROL_SOCKET = '/run/tor/control';
+	my $COOKIE_FILE    = '/run/tor/control.authcookie';
+
+	sub new {
+		my $cookie_hex = q{};
+
+		if (-r $COOKIE_FILE) {
+			open my $fh, '<:raw', $COOKIE_FILE or return "\n[!] ERROR: cannot read tor control cookie.\n\n";
+			local $INPUT_RECORD_SEPARATOR = undef;
+			my $cookie = <$fh>;
+			close $fh or return "\n[!] ERROR: cannot read tor control cookie.\n\n";
+			$cookie_hex = unpack 'H*', $cookie;
+		}
+
+		my $socket = IO::Socket::UNIX -> new(Peer => $CONTROL_SOCKET, Type => SOCK_STREAM())
+			or return "\n[!] ERROR: cannot reach tor control socket (is nipe started?).\n\n";
+
+		my $authenticate = $cookie_hex ? "AUTHENTICATE $cookie_hex\r\n" : "AUTHENTICATE\r\n";
+		print {$socket} $authenticate;
+		my $auth = <$socket>;
+
+		if (!defined $auth || $auth !~ /^250/smx) {
+			return "\n[!] ERROR: tor control authentication failed.\n\n";
+		}
+
+		print {$socket} "SIGNAL NEWNYM\r\n";
+		my $response = <$socket>;
+
+		if (defined $response && $response =~ /^250/smx) {
+			Time::HiRes::sleep($CIRCUIT_DELAY);
+			return Nipe::Component::Utils::Status -> new();
+		}
+
+		return "\n[!] ERROR: tor refused the NEWNYM signal.\n\n";
+	}
+}
+
+1;

--- a/lib/Nipe/Component/Utils/Helper.pm
+++ b/lib/Nipe/Component/Utils/Helper.pm
@@ -15,6 +15,7 @@ package Nipe::Component::Utils::Helper {
 				start         Start routing
 				stop          Stop routing
 				restart       Restart the Nipe circuit
+				newnym        Switch to a new circuit (new exit IP)
 				status        See status
 
 			END_HELP

--- a/nipe.pl
+++ b/nipe.pl
@@ -7,6 +7,7 @@ use Try::Tiny;
 use lib './lib/';
 use Nipe::Component::Engine::Stop;
 use Nipe::Component::Engine::Start;
+use Nipe::Component::Engine::Newnym;
 use Nipe::Network::Restart;
 use Nipe::Component::Utils::Status;
 use Nipe::Component::Utils::Helper;
@@ -18,36 +19,45 @@ our $VERSION = '0.0.8';
 sub main {
     my $argument = $ARGV[0];
 
-    if ($argument) {
-		if ($REAL_USER_ID != 0) {
-            die "Nipe must be run as root.\n";
-        }
-
-        my $commands = {
-            stop    => 'Nipe::Component::Engine::Stop',
-            start   => 'Nipe::Component::Engine::Start',
-            status  => 'Nipe::Component::Utils::Status',
-            restart => 'Nipe::Network::Restart',
-            install => 'Nipe::Network::Install',
-            help    => 'Nipe::Component::Utils::Helper'
-        };
-
-        try {
-            my $exec = $commands -> {$argument} -> new();
-
-            if ($exec ne '1') {
-                print $exec;
-            }
-        }
-
-        catch {
-            print "\n[!] ERROR: this command could not be run.\n\n";
-        };
-
-        return 1;
+    if (!$argument) {
+        return print Nipe::Component::Utils::Helper -> new();
     }
 
-    return print Nipe::Component::Utils::Helper -> new();
+    my $commands = {
+        stop    => 'Nipe::Component::Engine::Stop',
+        start   => 'Nipe::Component::Engine::Start',
+        status  => 'Nipe::Component::Utils::Status',
+        restart => 'Nipe::Network::Restart',
+        newnym  => 'Nipe::Component::Engine::Newnym',
+        install => 'Nipe::Network::Install',
+        help    => 'Nipe::Component::Utils::Helper',
+    };
+
+    my $module = $commands -> {$argument};
+
+    if (!$module) {
+        return print Nipe::Component::Utils::Helper -> new();
+    }
+
+    my %needs_root = map { $_ => 1 } qw(start stop restart newnym install);
+
+    if ($needs_root{$argument} && $REAL_USER_ID != 0) {
+        die "Nipe must be run as root.\n";
+    }
+
+    try {
+        my $exec = $module -> new();
+
+        if ($exec ne '1') {
+            print $exec;
+        }
+    }
+
+    catch {
+        print "\n[!] ERROR: $_\n";
+    };
+
+    return 1;
 }
 
 main();

--- a/tests/newnym.t
+++ b/tests/newnym.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::MockModule;
+use Test::More;
+
+use lib './lib';
+
+BEGIN {
+    use_ok('Nipe::Component::Engine::Newnym');
+}
+
+subtest 'reports an error when the control socket is unreachable' => sub {
+    plan tests => 1;
+
+    my $socket_mock = Test::MockModule -> new('IO::Socket::UNIX');
+    $socket_mock -> mock('new', sub { return; });
+
+    my $output = Nipe::Component::Engine::Newnym -> new();
+    ok(index($output, 'cannot reach tor control socket') >= 0, 'unreachable socket is reported');
+};
+
+done_testing();


### PR DESCRIPTION
### What was a problem?

There was no way to request a new circuit (a new exit IP) without a full `restart`, which tears down every rule and restarts tor.

### How this PR fixes the problem?

Adds `nipe newnym`: it talks to tor's control socket, authenticates with the cookie, sends `SIGNAL NEWNYM`, waits briefly for the new circuit, then prints the new status. `restart` is unchanged.

Two supporting changes in the same area:

- `nipe.pl` now prints the real error in the catch block instead of a generic message, and only requires root for the commands that touch tor or iptables (`status` and `help` no longer do).
- The remaining distro configs get `IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort` on `TransPort` (void already had it) so separate destinations do not share a circuit, and void gets the control socket and pid file the others already define.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

The control AUTHENTICATE line is built by a pure `auth_command` covered by `t/40-newnym.t`, and `t/00-compile.t` loads every module. On the non-Arch distros the control socket already exists; on Arch it is added by the lifecycle PR. Verified live in an Arch container: after `nipe newnym` the exit IP changes (45.66.35.35 to 185.220.101.26 in the test run).
